### PR TITLE
Fix: When you have two available clients both are opened instead of only the first available one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Tested on iOS 16.0 but should work on iOS and iPadOS 13.0 and up.
 	```xml
     <key>LSApplicationQueriesSchemes</key>
 	<array>
-	    <string>googlegmail://</string>
-	    <string>ms-outlook://</string>
-	    <string>readdle-spark://</string>
-	    <string>ymail://</string>
-	    <string>airmail://</string>
+	    <string>googlegmail</string>
+	    <string>ms-outlook</string>
+	    <string>readdle-spark</string>
+	    <string>ymail</string>
+	    <string>airmail</string>
 	</array>
     ```
 3. Add the component where you want to use it

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -90,10 +90,8 @@ public struct EmailLink<Content: View>: View {
             } else {
                 // Only open first found available client.
                 for client in availableClients {
-                    if UIApplication.shared.canOpenURL(client.value.url) {
-                        UIApplication.shared.open(client.value.url)
-                        break
-                    }
+                    UIApplication.shared.open(client.url)
+                    break
                 }
             }
         }) {
@@ -112,29 +110,23 @@ public struct EmailLink<Content: View>: View {
         var buttons = [ActionSheetButton]()
         
         for client in getAvailableClients() {
-            buttons.append(.default(
-                Text(clients[client]?.name ?? "")
-            , action: {
-                if let url = clients[client]?.url {
-                    UIApplication.shared.open(url)
-                }
-            }))
+            buttons.append(.default(Text(client.name), action: { UIApplication.shared.open(client.url) }))
         }
         
         buttons.append(.cancel())
         
         return buttons
     }
-    
-    private func getAvailableClients() -> [URLSchemes] {
-        var availableClients = [URLSchemes]()
-        
-        for scheme in URLSchemes.allCases {
-            if let url = URL(string: client.value.url), UIApplication.shared.canOpenURL(url) {
-                availableClients.append(scheme)
+
+    private func getAvailableClients() -> [EmailClient] {
+        var availableClients = [EmailClient]()
+
+        for client in clients {
+            if UIApplication.shared.canOpenURL(client.value.url) {
+                availableClients.append(client.value)
             }
         }
-        
+
         return availableClients
     }
     

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -10,7 +10,7 @@ public struct EmailLink<Content: View>: View {
     
     public init(to: String, subject: String = "", body: String = "", color: UIColor = .systemBlue, @ViewBuilder label: () -> Content) {
         // Ensure Info.plist includes required keys
-        self.checkInfoDictionary()
+        Self.checkInfoDictionary()
         
         // Set properties
         self.label = label()
@@ -83,11 +83,13 @@ public struct EmailLink<Content: View>: View {
 
     public var body: some View {
         Button(action: {
-            if getAvailableClients().count > 2 {
+            let availableClients = getAvailableClients()
+
+            if availableClients.count > 2 {
                 showAlert = true
             } else {
-                // Only open first found
-                for client in clients {
+                // Only open first found available client.
+                for client in availableClients {
                     if UIApplication.shared.canOpenURL(client.value.url) {
                         UIApplication.shared.open(client.value.url)
                         break
@@ -128,7 +130,7 @@ public struct EmailLink<Content: View>: View {
         var availableClients = [URLSchemes]()
         
         for scheme in URLSchemes.allCases {
-            if let url = URL(string: scheme.rawValue), UIApplication.shared.canOpenURL(url) {
+            if let url = URL(string: client.value.url), UIApplication.shared.canOpenURL(url) {
                 availableClients.append(scheme)
             }
         }

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -8,12 +8,12 @@ public struct EmailLink<Content: View>: View {
 
     private let label: Content
     private let clients: [EmailClient]
-    
+
     public init(to: String, subject: String = "", body: String = "", color: UIColor = .systemBlue, @ViewBuilder label: () -> Content) {
         // Set properties
         self.label = label()
         self.clients =  EmailClient.allClients(to: to, subject: subject, body: body)
-        
+
         // Force color for ActionSheet
         UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = color
     }
@@ -43,16 +43,16 @@ public struct EmailLink<Content: View>: View {
             self.checkInfoDictionary()
         }
     }
-    
+
     private func actionSheetButtons() -> [ActionSheetButton] {
         var buttons = [ActionSheetButton]()
-        
+
         for client in availableClients {
             buttons.append(.default(Text(client.name), action: { UIApplication.shared.open(client.url) }))
         }
-        
+
         buttons.append(.cancel())
-        
+
         return buttons
     }
 
@@ -67,7 +67,7 @@ public struct EmailLink<Content: View>: View {
 
         return availableClients
     }
-    
+
     private func checkInfoDictionary() {
         if let schemes = Bundle.main.infoDictionary?["LSApplicationQueriesSchemes"] as? Array<String> {
             // Bundle exists, check values

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -4,7 +4,8 @@ typealias ActionSheetButton = ActionSheet.Button
 
 public struct EmailLink<Content: View>: View {
     @State private var showAlert = false
-    
+    @State private var availableClients = [EmailClient]()
+
     private let label: Content
     private let clients: [EmailClient]
     
@@ -19,7 +20,7 @@ public struct EmailLink<Content: View>: View {
 
     public var body: some View {
         Button(action: {
-            let availableClients = getAvailableClients()
+            availableClients = getAvailableClients()
 
             if availableClients.count > 2 {
                 showAlert = true
@@ -46,7 +47,7 @@ public struct EmailLink<Content: View>: View {
     private func actionSheetButtons() -> [ActionSheetButton] {
         var buttons = [ActionSheetButton]()
         
-        for client in getAvailableClients() {
+        for client in availableClients {
             buttons.append(.default(Text(client.name), action: { UIApplication.shared.open(client.url) }))
         }
         

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -9,9 +9,6 @@ public struct EmailLink<Content: View>: View {
     private let clients: [EmailClient]
     
     public init(to: String, subject: String = "", body: String = "", color: UIColor = .systemBlue, @ViewBuilder label: () -> Content) {
-        // Ensure Info.plist includes required keys
-        Self.checkInfoDictionary()
-        
         // Set properties
         self.label = label()
         self.clients =  EmailClient.allClients(to: to, subject: subject, body: body)
@@ -27,7 +24,7 @@ public struct EmailLink<Content: View>: View {
             if availableClients.count > 2 {
                 showAlert = true
             } else {
-                // Only open first found available client.
+                // Only open the first found available client.
                 for client in availableClients {
                     UIApplication.shared.open(client.url)
                     break
@@ -42,6 +39,9 @@ public struct EmailLink<Content: View>: View {
                 message: Text("Which app do you want to use to send this email?"),
                 buttons: actionSheetButtons()
             )
+        }.onAppear() {
+            // Ensure Info.plist includes required keys before loading view.
+            self.checkInfoDictionary()
         }
     }
     
@@ -69,7 +69,7 @@ public struct EmailLink<Content: View>: View {
         return availableClients
     }
     
-    private static func checkInfoDictionary() {
+    private func checkInfoDictionary() {
         if let schemes = Bundle.main.infoDictionary?["LSApplicationQueriesSchemes"] as? Array<String> {
             // Bundle exists, check values
             for requiredScheme in URLSchemes.requiredSchemes() {

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -6,7 +6,7 @@ public struct EmailLink<Content: View>: View {
     @State private var showAlert = false
     
     private let label: Content
-    private let clients: [URLSchemes: EmailClient]
+    private let clients: [EmailClient]
     
     public init(to: String, subject: String = "", body: String = "", color: UIColor = .systemBlue, @ViewBuilder label: () -> Content) {
         // Ensure Info.plist includes required keys
@@ -15,7 +15,7 @@ public struct EmailLink<Content: View>: View {
         // Set properties
         self.label = label()
         self.clients =  [
-            .Gmail: EmailClient(
+            EmailClient(
                 name: "Gmail",
                 scheme: .Gmail,
                 host: "co",
@@ -25,7 +25,7 @@ public struct EmailLink<Content: View>: View {
                     URLQueryItem(name: "body", value: body)
                 ]
             ),
-            .Outlook: EmailClient(
+            EmailClient(
                 name: "Outlook",
                 scheme: .Outlook,
                 host: "compose",
@@ -35,7 +35,7 @@ public struct EmailLink<Content: View>: View {
                     URLQueryItem(name: "body", value: body)
                 ]
             ),
-            .Yahoo: EmailClient(
+            EmailClient(
                 name: "Yahoo",
                 scheme: .Yahoo,
                 host: "mail",
@@ -46,7 +46,7 @@ public struct EmailLink<Content: View>: View {
                     URLQueryItem(name: "body", value: body)
                 ]
             ),
-            .Spark: EmailClient(
+            EmailClient(
                 name: "Spark",
                 scheme: .Spark,
                 host: "compose",
@@ -56,7 +56,7 @@ public struct EmailLink<Content: View>: View {
                     URLQueryItem(name: "body", value: body)
                 ]
             ),
-            .AirMail: EmailClient(
+            EmailClient(
                 name: "Airmail",
                 scheme: .AirMail,
                 host: "compose",
@@ -66,7 +66,7 @@ public struct EmailLink<Content: View>: View {
                     URLQueryItem(name: "plainBody", value: body)
                 ]
             ),
-            .Default: EmailClient(
+            EmailClient(
                 name: "Default",
                 scheme: .Default,
                 path: to,

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -14,68 +14,7 @@ public struct EmailLink<Content: View>: View {
         
         // Set properties
         self.label = label()
-        self.clients =  [
-            EmailClient(
-                name: "Gmail",
-                scheme: .Gmail,
-                host: "co",
-                queryItems: [
-                    URLQueryItem(name: "to", value: to),
-                    URLQueryItem(name: "subject", value: subject),
-                    URLQueryItem(name: "body", value: body)
-                ]
-            ),
-            EmailClient(
-                name: "Outlook",
-                scheme: .Outlook,
-                host: "compose",
-                queryItems: [
-                    URLQueryItem(name: "to", value: to),
-                    URLQueryItem(name: "subject", value: subject),
-                    URLQueryItem(name: "body", value: body)
-                ]
-            ),
-            EmailClient(
-                name: "Yahoo",
-                scheme: .Yahoo,
-                host: "mail",
-                path: "/compose",
-                queryItems: [
-                    URLQueryItem(name: "to", value: to),
-                    URLQueryItem(name: "subject", value: subject),
-                    URLQueryItem(name: "body", value: body)
-                ]
-            ),
-            EmailClient(
-                name: "Spark",
-                scheme: .Spark,
-                host: "compose",
-                queryItems: [
-                    URLQueryItem(name: "recipient", value: to),
-                    URLQueryItem(name: "subject", value: subject),
-                    URLQueryItem(name: "body", value: body)
-                ]
-            ),
-            EmailClient(
-                name: "Airmail",
-                scheme: .AirMail,
-                host: "compose",
-                queryItems: [
-                    URLQueryItem(name: "to", value: to),
-                    URLQueryItem(name: "subject", value: subject),
-                    URLQueryItem(name: "plainBody", value: body)
-                ]
-            ),
-            EmailClient(
-                name: "Default",
-                scheme: .Default,
-                path: to,
-                queryItems: [
-                    URLQueryItem(name: "subject", value: subject),
-                    URLQueryItem(name: "body", value: body)
-                ]
-            )
-        ]
+        self.clients =  EmailClient.allClients(to: to, subject: subject, body: body)
         
         // Force color for ActionSheet
         UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = color
@@ -122,8 +61,8 @@ public struct EmailLink<Content: View>: View {
         var availableClients = [EmailClient]()
 
         for client in clients {
-            if UIApplication.shared.canOpenURL(client.value.url) {
-                availableClients.append(client.value)
+            if UIApplication.shared.canOpenURL(client.url) {
+                availableClients.append(client)
             }
         }
 

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -10,7 +10,7 @@ public struct EmailLink<Content: View>: View {
     
     public init(to: String, subject: String = "", body: String = "", color: UIColor = .systemBlue, @ViewBuilder label: () -> Content) {
         // Ensure Info.plist includes required keys
-        Self.checkInfoDictionary()
+        self.checkInfoDictionary()
         
         // Set properties
         self.label = label()
@@ -90,6 +90,7 @@ public struct EmailLink<Content: View>: View {
                 for client in clients {
                     if UIApplication.shared.canOpenURL(client.value.url) {
                         UIApplication.shared.open(client.value.url)
+                        break
                     }
                 }
             }

--- a/Sources/EmailLink/EmailLink.swift
+++ b/Sources/EmailLink/EmailLink.swift
@@ -24,10 +24,8 @@ public struct EmailLink<Content: View>: View {
             if availableClients.count > 2 {
                 showAlert = true
             } else {
-                // Only open the first found available client.
-                for client in availableClients {
-                    UIApplication.shared.open(client.url)
-                    break
+                if let url = availableClients.first?.url {
+                    UIApplication.shared.open(url)
                 }
             }
         }) {

--- a/Sources/EmailLink/Internal/EmailClient.swift
+++ b/Sources/EmailLink/Internal/EmailClient.swift
@@ -17,6 +17,7 @@ struct EmailClient {
 
     var url: URL {
         var components = URLComponents()
+
         components.scheme = scheme.formattedScheme()
         components.host = host
         components.path = path

--- a/Sources/EmailLink/Internal/EmailClient.swift
+++ b/Sources/EmailLink/Internal/EmailClient.swift
@@ -96,4 +96,3 @@ struct EmailClient {
         ]
     }
 }
-

--- a/Sources/EmailLink/Internal/EmailClient.swift
+++ b/Sources/EmailLink/Internal/EmailClient.swift
@@ -6,7 +6,7 @@ struct EmailClient {
     let host: String?
     let path: String
     let queryItems: [URLQueryItem]
-    
+
     init(name: String, scheme: URLSchemes, host: String? = nil, path: String = "", queryItems: [URLQueryItem]) {
         self.name = name
         self.scheme = scheme
@@ -14,19 +14,85 @@ struct EmailClient {
         self.path = path
         self.queryItems = queryItems
     }
-    
+
     var url: URL {
         var components = URLComponents()
-            components.scheme = scheme.formattedScheme()
-            components.host = host
-            components.path = path
-            components.queryItems = queryItems
-        
+        components.scheme = scheme.formattedScheme()
+        components.host = host
+        components.path = path
+        components.queryItems = queryItems
+
         // Ensure URL is generated
         guard let url = components.url else {
             fatalError("URL cannot be generated for \"\(name)\".")
         }
-        
+
         return url
     }
+
+    static func allClients(to: String, subject: String, body: String) -> [EmailClient] {
+        [
+            EmailClient(
+                name: "Gmail",
+                scheme: .Gmail,
+                host: "co",
+                queryItems: [
+                    URLQueryItem(name: "to", value: to),
+                    URLQueryItem(name: "subject", value: subject),
+                    URLQueryItem(name: "body", value: body)
+                ]
+            ),
+            EmailClient(
+                name: "Outlook",
+                scheme: .Outlook,
+                host: "compose",
+                queryItems: [
+                    URLQueryItem(name: "to", value: to),
+                    URLQueryItem(name: "subject", value: subject),
+                    URLQueryItem(name: "body", value: body)
+                ]
+            ),
+            EmailClient(
+                name: "Yahoo",
+                scheme: .Yahoo,
+                host: "mail",
+                path: "/compose",
+                queryItems: [
+                    URLQueryItem(name: "to", value: to),
+                    URLQueryItem(name: "subject", value: subject),
+                    URLQueryItem(name: "body", value: body)
+                ]
+            ),
+            EmailClient(
+                name: "Spark",
+                scheme: .Spark,
+                host: "compose",
+                queryItems: [
+                    URLQueryItem(name: "recipient", value: to),
+                    URLQueryItem(name: "subject", value: subject),
+                    URLQueryItem(name: "body", value: body)
+                ]
+            ),
+            EmailClient(
+                name: "Airmail",
+                scheme: .AirMail,
+                host: "compose",
+                queryItems: [
+                    URLQueryItem(name: "to", value: to),
+                    URLQueryItem(name: "subject", value: subject),
+                    URLQueryItem(name: "plainBody", value: body)
+                ]
+            ),
+            EmailClient(
+                name: "Default",
+                scheme: .Default,
+                path: to,
+                queryItems: [
+                    URLQueryItem(name: "subject", value: subject),
+                    URLQueryItem(name: "body", value: body)
+                ]
+            )
+        ]
+    }
 }
+

--- a/Sources/EmailLink/Internal/URLSchemes.swift
+++ b/Sources/EmailLink/Internal/URLSchemes.swift
@@ -5,13 +5,13 @@ enum URLSchemes: String, CaseIterable {
          Spark = "readdle-spark://",
          AirMail = "airmail://",
          Default = "mailto:"
-    
+
     func formattedScheme() -> String {
         self.rawValue
             .replacingOccurrences(of: ":", with: "")
             .replacingOccurrences(of: "//", with: "")
     }
-    
+
     static func requiredSchemes() -> [String] {
         [
             Self.Gmail.formattedScheme(),


### PR DESCRIPTION
closes: https://github.com/joe-scotto/EmailLink/issues/5

### Introduction

Hey, thank you so much for putting together this package, it has definitely saved me a lot of time having this available. I ran into a couple of issues when using the package that I wanted to try and fix which were:
- The main bug this issue tackles.
- Extra calls being made to check `canOpenURL` that could be reduced.

Let me know if I have missed anything or if you'd like me to clarify anything further 🙂 , once again, thanks for this package.

### Context

When you only have the default mail client and gmail installed, clicking on the `EmailLink` can result in both the default client and the gmail client being loaded. This occurs as we don't break out of the for loop we instead call open on all items.

### Changes
- Get the first available client instead of iterating through all clients.
- Move initialisation of `EmailClient` objects into `EmailClient` model object.
- Update configuration documentation as the entries don't require `://` and don't seem to work when they're added.
- Update available clients method so that it checks the actual email url, this reduces the amount of calls to `canOpenURL` and simplifies the initial clients data structure (no longer need a map).
- Shift dictionary check into `onAppear` function so we no longer require a static method.
- Cache `availableClients()` call between the button action and the call to action sheet so it is only called once.
- Remove all extra whitespace found on empty lines.

### Testing

I've tested the following locally in my application:
- `ButtonLink` only loads the gmail application when I only have the gmail application installed.
- `ButtonLink` shows alert view if I install outlook and it shows the three options. The calls made to `canOpenUrl` are only called once.